### PR TITLE
Bump upper bound on base

### DIFF
--- a/generic-lens-labels.cabal
+++ b/generic-lens-labels.cabal
@@ -35,7 +35,7 @@ library
   exposed-modules: Data.Generics.Labels
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.9 && <4.11,
+  build-depends:       base >=4.9 && <4.13,
                        generic-lens >= 0.3.0 &&  < 0.5.2
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
I've tested this with GHC head (currently on base 4.12) and it compiles and installs just fine, so the upper bound could be safely bumped to at least 4.13.

It would be great if this could get put on hackage after the change too so it builds out of the box.